### PR TITLE
Bug fix in getHeader. Case insensitive getHeader

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ class Request {
   }
 
   getHeader (name) {
-    this.getAllHeaders().get(name)
+    name = name.toLowerCase()
+    return this.getAllHeaders().get(name)
   }
 }
 
@@ -342,7 +343,7 @@ function addAll (lens) {
 
 function indexHeaders (headers) {
   const map = new Map()
-  for (var i = 0; i < headers.length; i += 2) map.set(headers[i], headers[i + 1])
+  for (var i = 0; i < headers.length; i += 2) map.set(headers[i].toLowerCase(), headers[i + 1])
   return map
 }
 


### PR DESCRIPTION
1. getHeader did not have 'return'
2. Made it case insensitive
