### PR TITLE
Fixes - Should not allow setHeader after Header sent

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -27,6 +27,7 @@ class Response {
   }
 
   setHeader (name, value) {
+    if (this.headerSent) throw new Error('Cannot write to headers after headers sent')
     const header = name + SEP + value + EOL
 
     // slow path but very unlikely (a *lot* of headers)


### PR DESCRIPTION
This should throw.

```
const turbo = require('./')

const hello = Buffer.from('hello world\n')

turbo.createServer(function (req, res) {
  res.setHeader('Content-Length', hello.length)
  res.write(hello)
  res.setHeader('hello', 'world') // This should throw
}).listen(8080)
```